### PR TITLE
Add secure connector

### DIFF
--- a/src/SecureConnector.php
+++ b/src/SecureConnector.php
@@ -1,0 +1,26 @@
+<?php
+namespace oliverlorenz\reactphpmqtt;
+
+use oliverlorenz\reactphpmqtt\protocol\Version;
+use React\Dns\Resolver\Resolver;
+use React\EventLoop\LoopInterface;
+use React\SocketClient\SecureConnector as ReactSecureConnector;
+
+/**
+ * Secure Connector
+ *
+ * @author Alin Eugen Deac <ade@vestergaardcompany.com>
+ * @package oliverlorenz\reactphpmqtt
+ */
+class SecureConnector extends Connector
+{
+
+    public function __construct(LoopInterface $loop, Resolver $resolver, Version $version)
+    {
+        parent::__construct($loop, $resolver, $version);
+
+        // Overwrite the socket connection, use secure connection instead
+        $this->socketConnector = new ReactSecureConnector($this->socketConnector, $loop);
+    }
+
+}


### PR DESCRIPTION
A simple extended version of the connector, which ensures to use react's secure connector as a wrapper.

This is a response to issue #8.

Please note, I have not created any integration tests for this, because I'm not sure how you wish to make use of such, if at all. Nevertheless, in a local test, using a local secure mosquitto broker, this connector appeared to be working.