### PR TITLE
Set Publish message content to payload property

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,14 @@ $connector = new oliverlorenz\reactphpmqtt\Connector($loop, $resolver, $version)
 
 $p = $connector->create($config['server'], $config['port'], $config['options']);
 $p->then(function(\React\Stream\Stream $stream) use ($connector) {
+    $stream->on('PUBLISH', function(\oliverlorenz\reactphpmqtt\packet\Publish $message) {
+        print_r($message);
+    });
+    
     $connector->subscribe($stream, 'a/b', 0);
     $connector->subscribe($stream, 'a/c', 0);
 });
-$connector->onPublishReceived(function($message) {
-    print_r($message);
-});
+
 $loop->run();
 ```
 

--- a/examples/connectSubscribe.php
+++ b/examples/connectSubscribe.php
@@ -14,6 +14,15 @@ $connector = new oliverlorenz\reactphpmqtt\Connector($loop, $resolver, $version)
 
 $p = $connector->create($config['server'], $config['port'], $config['options']);
 $p->then(function(\React\Stream\Stream $stream) use ($connector) {
+    $stream->on('PUBLISH', function(\oliverlorenz\reactphpmqtt\packet\Publish $message) {
+        printf(
+            'Received payload "%s" for topic "%s"%s',
+            $message->getPayload(),
+            $message->getTopic(),
+            PHP_EOL
+        );
+    });
+
     return $connector->subscribe($stream, 'hello/world', 0);
 });
 

--- a/src/packet/ControlPacket.php
+++ b/src/packet/ControlPacket.php
@@ -46,7 +46,8 @@ abstract class ControlPacket {
 
     protected static function checkRawInputValidControlPackageType($rawInput)
     {
-        if (!$rawInput{1} === static::getControlPacketType()) {
+        $packetType = ord($rawInput{0}) >> 4;
+        if ($packetType !== static::getControlPacketType()) {
             throw new \RuntimeException('raw input is not valid for this control packet');
         }
     }

--- a/src/packet/ControlPacket.php
+++ b/src/packet/ControlPacket.php
@@ -20,7 +20,7 @@ abstract class ControlPacket {
 
     protected $variableHeader;
 
-    protected $payload;
+    protected $payload = '';
 
     protected $useVariableHeader = false;
     protected $useFixedHeader = true;

--- a/src/packet/ControlPacket.php
+++ b/src/packet/ControlPacket.php
@@ -58,10 +58,10 @@ abstract class ControlPacket {
 
     protected function getPayloadLength()
     {
-        return strlen($this->payload);
+        return strlen($this->getPayload());
     }
 
-    protected function getPayload()
+    public function getPayload()
     {
         return $this->payload;
     }
@@ -104,7 +104,6 @@ abstract class ControlPacket {
 
     /**
      * @param $fieldPayload
-     * @return string
      */
     public function addLengthPrefixedField($fieldPayload)
     {

--- a/src/packet/Publish.php
+++ b/src/packet/Publish.php
@@ -27,9 +27,6 @@ class Publish extends ControlPacket {
 
     protected $useVariableHeader = true;
 
-    /** @var null|\DateTime $receiveTimestamp */
-    protected $receiveTimestamp = null;
-
     public static function getControlPacketType()
     {
         return ControlPacketType::PUBLISH;
@@ -43,7 +40,7 @@ class Publish extends ControlPacket {
         //TODO 3.3.2.2 Packet Identifier not yet supported
         $topic = static::getPayloadLengthPrefixFieldInRawInput(2, $rawInput);
         $packet->setTopic($topic);
-//        $packet->setReceiveTimestamp(new \DateTime());
+
         $byte1 = $rawInput{0};
         if (!empty($byte1)) {
             $packet->setRetain(($byte1 & 1) === 1);
@@ -137,14 +134,6 @@ class Publish extends ControlPacket {
         return $this->getLengthPrefixField($this->topic);
     }
 
-//    /**
-//     * @param \DateTime $dateTime
-//     */
-//    private function setReceiveTimestamp($dateTime)
-//    {
-//        $this->receiveTimestamp = $dateTime;
-//    }
-
     protected function addReservedBitsToFixedHeaderControlPacketType($byte1)
     {
         $qosByte = 0;
@@ -165,6 +154,4 @@ class Publish extends ControlPacket {
 
         return $byte1;
     }
-
-
 }

--- a/src/packet/Publish.php
+++ b/src/packet/Publish.php
@@ -13,9 +13,6 @@ class Publish extends ControlPacket {
 
     protected $messageId;
 
-    /** @var string $message */
-    protected $message = null;
-
     protected $topic;
 
     protected $qos = 0;
@@ -55,12 +52,11 @@ class Publish extends ControlPacket {
                 $packet->setQos(2);
             }
         }
-        $packet->setMessage(
-            substr(
-                $rawInput,
-                4 + strlen($topic)
-            )
+        $packet->payload = substr(
+            $rawInput,
+            4 + strlen($topic)
         );
+
         return $packet;
     }
 
@@ -115,6 +111,14 @@ class Publish extends ControlPacket {
     }
 
     /**
+     * @return string
+     */
+    public function getTopic()
+    {
+        return $this->topic;
+    }
+
+    /**
      * @return int
      */
     public function getQos()
@@ -137,14 +141,6 @@ class Publish extends ControlPacket {
     private function setReceiveTimestamp($dateTime)
     {
         $this->receiveTimestamp = $dateTime;
-    }
-
-    /**
-     * @param string $message
-     */
-    private function setMessage($message)
-    {
-        $this->message = $message;
     }
 
     protected function addReservedBitsToFixedHeaderControlPacketType($byte1)

--- a/src/packet/Publish.php
+++ b/src/packet/Publish.php
@@ -31,26 +31,24 @@ class Publish extends ControlPacket {
         return ControlPacketType::PUBLISH;
     }
 
-    public function __construct(Version $version)
-    {
-        parent::__construct($version);
-    }
-
     public static function parse(Version $version, $rawInput)
     {
         /** @var Publish $packet */
         $packet = parent::parse($version, $rawInput);
+
+        //TODO 3.3.2.2 Packet Identifier not yet supported
         $topic = static::getPayloadLengthPrefixFieldInRawInput(2, $rawInput);
         $packet->setTopic($topic);
 //        $packet->setReceiveTimestamp(new \DateTime());
-        if (!empty($rawInput{0})) {
-            $packet->setRetain(($rawInput{0} & 1) === 1);
-            $packet->setDup(($rawInput{0} & 8) === 8);
-            if (($rawInput{0} & 2) === 2) {
+        $byte1 = $rawInput{0};
+        if (!empty($byte1)) {
+            $packet->setRetain(($byte1 & 1) === 1);
+            if (($byte1 & 2) === 2) {
                 $packet->setQos(1);
-            } elseif (($rawInput{0} & 4) === 4) {
+            } elseif (($byte1 & 4) === 4) {
                 $packet->setQos(2);
             }
+            $packet->setDup(($byte1 & 8) === 8);
         }
         $packet->payload = substr(
             $rawInput,

--- a/src/packet/Publish.php
+++ b/src/packet/Publish.php
@@ -13,13 +13,13 @@ class Publish extends ControlPacket {
 
     protected $messageId;
 
-    protected $topic;
+    protected $topic = '';
 
     protected $qos = 0;
 
-    protected $dup;
+    protected $dup = false;
 
-    protected $retain;
+    protected $retain = false;
 
     protected $useVariableHeader = true;
 
@@ -42,7 +42,7 @@ class Publish extends ControlPacket {
         $packet = parent::parse($version, $rawInput);
         $topic = static::getPayloadLengthPrefixFieldInRawInput(2, $rawInput);
         $packet->setTopic($topic);
-        $packet->setReceiveTimestamp(new \DateTime());
+//        $packet->setReceiveTimestamp(new \DateTime());
         if (!empty($rawInput{0})) {
             $packet->setRetain(($rawInput{0} & 1) === 1);
             $packet->setDup(($rawInput{0} & 8) === 8);
@@ -135,13 +135,13 @@ class Publish extends ControlPacket {
         return $this->getLengthPrefixField($this->topic);
     }
 
-    /**
-     * @param \DateTime $dateTime
-     */
-    private function setReceiveTimestamp($dateTime)
-    {
-        $this->receiveTimestamp = $dateTime;
-    }
+//    /**
+//     * @param \DateTime $dateTime
+//     */
+//    private function setReceiveTimestamp($dateTime)
+//    {
+//        $this->receiveTimestamp = $dateTime;
+//    }
 
     protected function addReservedBitsToFixedHeaderControlPacketType($byte1)
     {

--- a/tests/unit/packet/PublishTest.php
+++ b/tests/unit/packet/PublishTest.php
@@ -225,11 +225,12 @@ class PublishTest extends PHPUnit_Framework_TestCase {
     {
         $input =
             chr($bit) .
-            chr(4) .
+//            chr(4) .
+            chr(2) .
             chr(0) .
+            chr(0) /*.
             chr(0) .
-            chr(0) .
-            chr(10)
+            chr(10)*/
         ;
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
         $parsedPacket = \oliverlorenz\reactphpmqtt\packet\Publish::parse($version, $input);
@@ -247,11 +248,12 @@ class PublishTest extends PHPUnit_Framework_TestCase {
     {
         $input =
             chr(49) .
-            chr(4) .
+//            chr(4) .
+            chr(2) .
             chr(0) .
+            chr(0) /*.
             chr(0) .
-            chr(0) .
-            chr(10)
+            chr(10)*/
         ;
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
         $parsedPacket = \oliverlorenz\reactphpmqtt\packet\Publish::parse($version, $input);
@@ -269,11 +271,12 @@ class PublishTest extends PHPUnit_Framework_TestCase {
     {
         $input =
             chr(56) .
-            chr(4) .
+//            chr(4) .
+            chr(2) .
             chr(0) .
+            chr(0) /*.
             chr(0) .
-            chr(0) .
-            chr(10)
+            chr(10)*/
         ;
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
         $parsedPacket = \oliverlorenz\reactphpmqtt\packet\Publish::parse($version, $input);

--- a/tests/unit/packet/PublishTest.php
+++ b/tests/unit/packet/PublishTest.php
@@ -5,98 +5,117 @@
  * Time: 16:35
  */
 
+use oliverlorenz\reactphpmqtt\packet\MessageHelper;
+use oliverlorenz\reactphpmqtt\packet\Publish;
+
 class PublishTest extends PHPUnit_Framework_TestCase {
 
     public function testPublishStandard()
     {
-        $this->assertEquals(
-            \oliverlorenz\reactphpmqtt\packet\Publish::getControlPacketType(),
-            3
-        );
+        $this->assertEquals(3, Publish::getControlPacketType());
     }
 
-    public function testPublishStandarWithQos2()
+    public function testPublishStandardWithQos2()
     {
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new \oliverlorenz\reactphpmqtt\packet\Publish($version);
+        $packet = new Publish($version);
         $packet->setQos(2);
+
         $this->assertEquals(
-            \oliverlorenz\reactphpmqtt\packet\MessageHelper::getReadableByRawString(
+            MessageHelper::getReadableByRawString(
                 chr(52) .
                 chr(2) .
                 chr(0) .
                 chr(0) .
                 chr(49)
             ),
-            \oliverlorenz\reactphpmqtt\packet\MessageHelper::getReadableByRawString($packet->get() . 1)
+            MessageHelper::getReadableByRawString($packet->get() . 1)
         );
     }
 
     public function testPublishStandarWithQos1()
     {
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new \oliverlorenz\reactphpmqtt\packet\Publish($version);
+        $packet = new Publish($version);
         $packet->setQos(1);
         $this->assertEquals(
-            \oliverlorenz\reactphpmqtt\packet\MessageHelper::getReadableByRawString(
+            MessageHelper::getReadableByRawString(
                 chr(50) .
                 chr(2) .
                 chr(0) .
                 chr(0) .
                 chr(49)
             ),
-            \oliverlorenz\reactphpmqtt\packet\MessageHelper::getReadableByRawString($packet->get() . 1)
+            MessageHelper::getReadableByRawString($packet->get() . 1)
         );
     }
 
-    public function testPublishStandarWithQos0()
+    public function testPublishStandardWithQos0()
     {
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new \oliverlorenz\reactphpmqtt\packet\Publish($version);
+        $packet = new Publish($version);
         $packet->setQos(0);
         $this->assertEquals(
-            \oliverlorenz\reactphpmqtt\packet\MessageHelper::getReadableByRawString(
+            MessageHelper::getReadableByRawString(
                 chr(48) .
                 chr(2) .
                 chr(0) .
                 chr(0) .
                 chr(49)
             ),
-            \oliverlorenz\reactphpmqtt\packet\MessageHelper::getReadableByRawString($packet->get() . 1)
+            MessageHelper::getReadableByRawString($packet->get() . 1)
         );
     }
 
-    public function testPublishStandarWithDup()
+    public function testPublishStandardWithDup()
     {
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new \oliverlorenz\reactphpmqtt\packet\Publish($version);
+        $packet = new Publish($version);
         $packet->setDup(true);
         $this->assertEquals(
-            \oliverlorenz\reactphpmqtt\packet\MessageHelper::getReadableByRawString(
+            MessageHelper::getReadableByRawString(
                 chr(56) .
                 chr(2) .
                 chr(0) .
                 chr(0) .
                 chr(49)
             ),
-            \oliverlorenz\reactphpmqtt\packet\MessageHelper::getReadableByRawString($packet->get() . 1)
+            MessageHelper::getReadableByRawString($packet->get() . 1)
         );
     }
 
-    public function testPublishStandarWithRetain()
+    public function testPublishStandardWithRetain()
     {
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new \oliverlorenz\reactphpmqtt\packet\Publish($version);
+        $packet = new Publish($version);
         $packet->setRetain(true);
         $this->assertEquals(
-            \oliverlorenz\reactphpmqtt\packet\MessageHelper::getReadableByRawString(
+            MessageHelper::getReadableByRawString(
                 chr(49) .
                 chr(2) .
                 chr(0) .
                 chr(0) .
                 chr(49)
             ),
-            \oliverlorenz\reactphpmqtt\packet\MessageHelper::getReadableByRawString($packet->get() . 1)
+            MessageHelper::getReadableByRawString($packet->get() . 1)
+        );
+    }
+
+    public function testPublishWithPayload()
+    {
+        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
+        $packet = new Publish($version);
+        $packet->addRawToPayLoad('This is the payload');
+
+        $this->assertEquals(
+            MessageHelper::getReadableByRawString(
+                chr(48) .
+                chr(21) .
+                chr(0) .
+                chr(0) .
+                'This is the payload'
+            ),
+            MessageHelper::getReadableByRawString($packet->get())
         );
     }
 
@@ -105,10 +124,10 @@ class PublishTest extends PHPUnit_Framework_TestCase {
         $topic = 'topictest';
 
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new \oliverlorenz\reactphpmqtt\packet\Publish($version);
+        $packet = new Publish($version);
         $packet->setTopic($topic);
 
-        $reflection = new ReflectionClass('\oliverlorenz\reactphpmqtt\packet\Publish');
+        $reflection = new ReflectionClass('oliverlorenz\reactphpmqtt\packet\Publish');
         $property = $reflection->getProperty('topic');
         $property->setAccessible(true);
 
@@ -123,10 +142,10 @@ class PublishTest extends PHPUnit_Framework_TestCase {
         $qos = 2;
 
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new \oliverlorenz\reactphpmqtt\packet\Publish($version);
+        $packet = new Publish($version);
         $packet->setQos($qos);
 
-        $reflection = new ReflectionClass('\oliverlorenz\reactphpmqtt\packet\Publish');
+        $reflection = new ReflectionClass('oliverlorenz\reactphpmqtt\packet\Publish');
         $property = $reflection->getProperty('qos');
         $property->setAccessible(true);
 
@@ -141,10 +160,10 @@ class PublishTest extends PHPUnit_Framework_TestCase {
         $dup = true;
 
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new \oliverlorenz\reactphpmqtt\packet\Publish($version);
+        $packet = new Publish($version);
         $packet->setDup($dup);
 
-        $reflection = new ReflectionClass('\oliverlorenz\reactphpmqtt\packet\Publish');
+        $reflection = new ReflectionClass('oliverlorenz\reactphpmqtt\packet\Publish');
         $property = $reflection->getProperty('dup');
         $property->setAccessible(true);
 
@@ -159,10 +178,10 @@ class PublishTest extends PHPUnit_Framework_TestCase {
         $retain = true;
 
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new \oliverlorenz\reactphpmqtt\packet\Publish($version);
+        $packet = new Publish($version);
         $packet->setRetain($retain);
 
-        $reflection = new ReflectionClass('\oliverlorenz\reactphpmqtt\packet\Publish');
+        $reflection = new ReflectionClass('oliverlorenz\reactphpmqtt\packet\Publish');
         $property = $reflection->getProperty('retain');
         $property->setAccessible(true);
 
@@ -177,9 +196,9 @@ class PublishTest extends PHPUnit_Framework_TestCase {
         $topic = 'topictest';
 
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new \oliverlorenz\reactphpmqtt\packet\Publish($version);
+        $packet = new Publish($version);
         $return = $packet->setTopic($topic);
-        $this->assertInstanceOf('\oliverlorenz\reactphpmqtt\packet\Publish', $return);
+        $this->assertInstanceOf('oliverlorenz\reactphpmqtt\packet\Publish', $return);
     }
 
     public function testSetMessageId()
@@ -187,10 +206,10 @@ class PublishTest extends PHPUnit_Framework_TestCase {
         $messageId = 1;
 
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new \oliverlorenz\reactphpmqtt\packet\Publish($version);
+        $packet = new Publish($version);
         $packet->setMessageId($messageId);
 
-        $reflection = new ReflectionClass('\oliverlorenz\reactphpmqtt\packet\Publish');
+        $reflection = new ReflectionClass('oliverlorenz\reactphpmqtt\packet\Publish');
         $property = $reflection->getProperty('messageId');
         $property->setAccessible(true);
 
@@ -205,9 +224,9 @@ class PublishTest extends PHPUnit_Framework_TestCase {
         $messageId = 1;
 
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new \oliverlorenz\reactphpmqtt\packet\Publish($version);
+        $packet = new Publish($version);
         $return = $packet->setMessageId($messageId);
-        $this->assertInstanceOf('\oliverlorenz\reactphpmqtt\packet\Publish', $return);
+        $this->assertInstanceOf('oliverlorenz\reactphpmqtt\packet\Publish', $return);
     }
 
     public function qosProvider() {
@@ -233,15 +252,12 @@ class PublishTest extends PHPUnit_Framework_TestCase {
             chr(10)*/
         ;
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $parsedPacket = \oliverlorenz\reactphpmqtt\packet\Publish::parse($version, $input);
+        $parsedPacket = Publish::parse($version, $input);
 
-        $comparisonPacket = new \oliverlorenz\reactphpmqtt\packet\Publish($version);
+        $comparisonPacket = new Publish($version);
         $comparisonPacket->setQos($qos);
 
-        $this->assertEquals(
-            \oliverlorenz\reactphpmqtt\packet\MessageHelper::getReadableByRawString($parsedPacket->get()),
-            \oliverlorenz\reactphpmqtt\packet\MessageHelper::getReadableByRawString($comparisonPacket->get())
-        );
+        $this->assertPacketEquals($comparisonPacket, $parsedPacket);
     }
 
     public function testParseWithRetain()
@@ -256,15 +272,12 @@ class PublishTest extends PHPUnit_Framework_TestCase {
             chr(10)*/
         ;
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $parsedPacket = \oliverlorenz\reactphpmqtt\packet\Publish::parse($version, $input);
+        $parsedPacket = Publish::parse($version, $input);
 
-        $comparisonPacket = new \oliverlorenz\reactphpmqtt\packet\Publish($version);
+        $comparisonPacket = new Publish($version);
         $comparisonPacket->setRetain(true);
 
-        $this->assertEquals(
-            \oliverlorenz\reactphpmqtt\packet\MessageHelper::getReadableByRawString($parsedPacket->get()),
-            \oliverlorenz\reactphpmqtt\packet\MessageHelper::getReadableByRawString($comparisonPacket->get())
-        );
+        $this->assertPacketEquals($comparisonPacket, $parsedPacket);
     }
 
     public function testParseWithDup()
@@ -279,14 +292,19 @@ class PublishTest extends PHPUnit_Framework_TestCase {
             chr(10)*/
         ;
         $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $parsedPacket = \oliverlorenz\reactphpmqtt\packet\Publish::parse($version, $input);
+        $parsedPacket = Publish::parse($version, $input);
 
-        $comparisonPacket = new \oliverlorenz\reactphpmqtt\packet\Publish($version);
+        $comparisonPacket = new Publish($version);
         $comparisonPacket->setDup(true);
 
+        $this->assertPacketEquals($comparisonPacket, $parsedPacket);
+    }
+    
+    private function assertPacketEquals(Publish $expected, Publish $actual)
+    {
         $this->assertEquals(
-            \oliverlorenz\reactphpmqtt\packet\MessageHelper::getReadableByRawString($parsedPacket->get()),
-            \oliverlorenz\reactphpmqtt\packet\MessageHelper::getReadableByRawString($comparisonPacket->get())
+            MessageHelper::getReadableByRawString($expected->get()),
+            MessageHelper::getReadableByRawString($actual->get())
         );
     }
 }

--- a/tests/unit/packet/PublishTest.php
+++ b/tests/unit/packet/PublishTest.php
@@ -25,10 +25,9 @@ class PublishTest extends PHPUnit_Framework_TestCase {
             chr(0b00110100) .
             chr(2) .
             chr(0) .
-            chr(0) .
-            chr(49);
+            chr(0);
 
-        $this->assertSerialisedPacketEquals($expected, $packet->get() . 1);
+        $this->assertSerialisedPacketEquals($expected, $packet->get());
     }
 
     public function testPublishStandardWithQos1()
@@ -40,10 +39,9 @@ class PublishTest extends PHPUnit_Framework_TestCase {
             chr(0b00110010) .
             chr(2) .
             chr(0) .
-            chr(0) .
-            chr(49);
+            chr(0);
 
-        $this->assertSerialisedPacketEquals($expected, $packet->get() . 1);
+        $this->assertSerialisedPacketEquals($expected, $packet->get());
     }
 
     public function testPublishStandardWithQos0()
@@ -55,10 +53,9 @@ class PublishTest extends PHPUnit_Framework_TestCase {
             chr(0b00110000) .
             chr(2) .
             chr(0) .
-            chr(0) .
-            chr(49);
+            chr(0);
 
-        $this->assertSerialisedPacketEquals($expected, $packet->get() . 1);
+        $this->assertSerialisedPacketEquals($expected, $packet->get());
     }
 
     public function testPublishStandardWithDup()
@@ -70,10 +67,9 @@ class PublishTest extends PHPUnit_Framework_TestCase {
             chr(0b00111000) .
             chr(2) .
             chr(0) .
-            chr(0) .
-            chr(49);
+            chr(0);
 
-        $this->assertSerialisedPacketEquals($expected, $packet->get() . 1);
+        $this->assertSerialisedPacketEquals($expected, $packet->get());
     }
 
     public function testPublishStandardWithRetain()
@@ -85,10 +81,9 @@ class PublishTest extends PHPUnit_Framework_TestCase {
             chr(0b00110001) .
             chr(2) .
             chr(0) .
-            chr(0) .
-            chr(49);
+            chr(0);
 
-        $this->assertSerialisedPacketEquals($expected, $packet->get() . 1);
+        $this->assertSerialisedPacketEquals($expected, $packet->get());
     }
 
     public function testPublishWithPayload()
@@ -146,40 +141,6 @@ class PublishTest extends PHPUnit_Framework_TestCase {
         );
     }
 
-    public function testSetDup()
-    {
-        $dup = true;
-
-        $packet = new Publish(new Version4());
-        $packet->setDup($dup);
-
-        $reflection = new ReflectionClass('oliverlorenz\reactphpmqtt\packet\Publish');
-        $property = $reflection->getProperty('dup');
-        $property->setAccessible(true);
-
-        $this->assertEquals(
-            $property->getValue($packet),
-            $dup
-        );
-    }
-
-    public function testSetRetain()
-    {
-        $retain = true;
-
-        $packet = new Publish(new Version4());
-        $packet->setRetain($retain);
-
-        $reflection = new ReflectionClass('oliverlorenz\reactphpmqtt\packet\Publish');
-        $property = $reflection->getProperty('retain');
-        $property->setAccessible(true);
-
-        $this->assertEquals(
-            $property->getValue($packet),
-            $retain
-        );
-    }
-
     public function testSetTopicReturn()
     {
         $topic = 'topictest';
@@ -187,23 +148,6 @@ class PublishTest extends PHPUnit_Framework_TestCase {
         $packet = new Publish(new Version4());
         $return = $packet->setTopic($topic);
         $this->assertInstanceOf('oliverlorenz\reactphpmqtt\packet\Publish', $return);
-    }
-
-    public function testSetMessageId()
-    {
-        $messageId = 1;
-
-        $packet = new Publish(new Version4());
-        $packet->setMessageId($messageId);
-
-        $reflection = new ReflectionClass('oliverlorenz\reactphpmqtt\packet\Publish');
-        $property = $reflection->getProperty('messageId');
-        $property->setAccessible(true);
-
-        $this->assertEquals(
-            $property->getValue($packet),
-            $messageId
-        );
     }
 
     public function testSetMessageIdReturn()
@@ -230,13 +174,9 @@ class PublishTest extends PHPUnit_Framework_TestCase {
     {
         $input =
             chr($byte1) .
-//            chr(4) .
             chr(2) .
             chr(0) .
-            chr(0) /*.
-            chr(0) .
-            chr(10)*/
-        ;
+            chr(0);
         $parsedPacket = Publish::parse(new Version4(), $input);
 
         $comparisonPacket = new Publish(new Version4());
@@ -249,13 +189,9 @@ class PublishTest extends PHPUnit_Framework_TestCase {
     {
         $input =
             chr(0b00110001) .
-//            chr(4) .
             chr(2) .
             chr(0) .
-            chr(0) /*.
-            chr(0) .
-            chr(10)*/
-        ;
+            chr(0);
         $parsedPacket = Publish::parse(new Version4(), $input);
 
         $comparisonPacket = new Publish(new Version4());
@@ -268,13 +204,9 @@ class PublishTest extends PHPUnit_Framework_TestCase {
     {
         $input =
             chr(0b00111000) .
-//            chr(4) .
             chr(2) .
             chr(0) .
-            chr(0) /*.
-            chr(0) .
-            chr(10)*/
-        ;
+            chr(0);
         $parsedPacket = Publish::parse(new Version4(), $input);
 
         $comparisonPacket = new Publish(new Version4());
@@ -294,10 +226,10 @@ class PublishTest extends PHPUnit_Framework_TestCase {
             chr(0) .
             chr(0) .
             'My payload';
-
         $parsedPacket = Publish::parse(new Version4(), $input);
 
         $this->assertPacketEquals($expectedPacket, $parsedPacket);
+        $this->assertEquals('My payload', $parsedPacket->getPayload());
     }
 
     private function assertPacketEquals(Publish $expected, Publish $actual)

--- a/tests/unit/packet/PublishTest.php
+++ b/tests/unit/packet/PublishTest.php
@@ -7,6 +7,7 @@
 
 use oliverlorenz\reactphpmqtt\packet\MessageHelper;
 use oliverlorenz\reactphpmqtt\packet\Publish;
+use oliverlorenz\reactphpmqtt\protocol\Version4;
 
 class PublishTest extends PHPUnit_Framework_TestCase {
 
@@ -17,123 +18,114 @@ class PublishTest extends PHPUnit_Framework_TestCase {
 
     public function testPublishStandardWithQos2()
     {
-        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new Publish($version);
+        $packet = new Publish(new Version4());
         $packet->setQos(2);
 
-        $this->assertEquals(
-            MessageHelper::getReadableByRawString(
-                chr(52) .
-                chr(2) .
-                chr(0) .
-                chr(0) .
-                chr(49)
-            ),
-            MessageHelper::getReadableByRawString($packet->get() . 1)
-        );
+        $expected =
+            chr(0b00110100) .
+            chr(2) .
+            chr(0) .
+            chr(0) .
+            chr(49);
+
+        $this->assertSerialisedPacketEquals($expected, $packet->get() . 1);
     }
 
-    public function testPublishStandarWithQos1()
+    public function testPublishStandardWithQos1()
     {
-        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new Publish($version);
+        $packet = new Publish(new Version4());
         $packet->setQos(1);
-        $this->assertEquals(
-            MessageHelper::getReadableByRawString(
-                chr(50) .
-                chr(2) .
-                chr(0) .
-                chr(0) .
-                chr(49)
-            ),
-            MessageHelper::getReadableByRawString($packet->get() . 1)
-        );
+
+        $expected =
+            chr(0b00110010) .
+            chr(2) .
+            chr(0) .
+            chr(0) .
+            chr(49);
+
+        $this->assertSerialisedPacketEquals($expected, $packet->get() . 1);
     }
 
     public function testPublishStandardWithQos0()
     {
-        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new Publish($version);
+        $packet = new Publish(new Version4());
         $packet->setQos(0);
-        $this->assertEquals(
-            MessageHelper::getReadableByRawString(
-                chr(48) .
-                chr(2) .
-                chr(0) .
-                chr(0) .
-                chr(49)
-            ),
-            MessageHelper::getReadableByRawString($packet->get() . 1)
-        );
+
+        $expected =
+            chr(0b00110000) .
+            chr(2) .
+            chr(0) .
+            chr(0) .
+            chr(49);
+
+        $this->assertSerialisedPacketEquals($expected, $packet->get() . 1);
     }
 
     public function testPublishStandardWithDup()
     {
-        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new Publish($version);
+        $packet = new Publish(new Version4());
         $packet->setDup(true);
-        $this->assertEquals(
-            MessageHelper::getReadableByRawString(
-                chr(56) .
-                chr(2) .
-                chr(0) .
-                chr(0) .
-                chr(49)
-            ),
-            MessageHelper::getReadableByRawString($packet->get() . 1)
-        );
+
+        $expected =
+            chr(0b00111000) .
+            chr(2) .
+            chr(0) .
+            chr(0) .
+            chr(49);
+
+        $this->assertSerialisedPacketEquals($expected, $packet->get() . 1);
     }
 
     public function testPublishStandardWithRetain()
     {
-        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new Publish($version);
+        $packet = new Publish(new Version4());
         $packet->setRetain(true);
-        $this->assertEquals(
-            MessageHelper::getReadableByRawString(
-                chr(49) .
-                chr(2) .
-                chr(0) .
-                chr(0) .
-                chr(49)
-            ),
-            MessageHelper::getReadableByRawString($packet->get() . 1)
-        );
+
+        $expected =
+            chr(0b00110001) .
+            chr(2) .
+            chr(0) .
+            chr(0) .
+            chr(49);
+
+        $this->assertSerialisedPacketEquals($expected, $packet->get() . 1);
     }
 
     public function testPublishWithPayload()
     {
-        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new Publish($version);
+        $packet = new Publish(new Version4());
         $packet->addRawToPayLoad('This is the payload');
 
-        $this->assertEquals(
-            MessageHelper::getReadableByRawString(
-                chr(48) .
-                chr(21) .
-                chr(0) .
-                chr(0) .
-                'This is the payload'
-            ),
-            MessageHelper::getReadableByRawString($packet->get())
-        );
+        $expected =
+            chr(0b00110000) .
+            chr(21) .
+            chr(0) .
+            chr(0) .
+            'This is the payload';
+
+        $this->assertEquals('This is the payload', $packet->getPayload());
+
+        $this->assertSerialisedPacketEquals($expected, $packet->get());
     }
 
-    public function testSetTopic()
+    public function testTopic()
     {
-        $topic = 'topictest';
+        $packet = new Publish(new Version4());
 
-        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new Publish($version);
-        $packet->setTopic($topic);
+        $packet->setTopic('topic/test');
 
-        $reflection = new ReflectionClass('oliverlorenz\reactphpmqtt\packet\Publish');
-        $property = $reflection->getProperty('topic');
-        $property->setAccessible(true);
+        $expected =
+            chr(0b00110000) .
+            chr(12) .
+            chr(0) .
+            chr(10) .
+            'topic/test';
 
-        $this->assertEquals(
-            $property->getValue($packet),
-            $topic
+        $this->assertEquals('topic/test', $packet->getTopic());
+
+        $this->assertSerialisedPacketEquals(
+            $expected,
+            $packet->get()
         );
     }
 
@@ -141,8 +133,7 @@ class PublishTest extends PHPUnit_Framework_TestCase {
     {
         $qos = 2;
 
-        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new Publish($version);
+        $packet = new Publish(new Version4());
         $packet->setQos($qos);
 
         $reflection = new ReflectionClass('oliverlorenz\reactphpmqtt\packet\Publish');
@@ -159,8 +150,7 @@ class PublishTest extends PHPUnit_Framework_TestCase {
     {
         $dup = true;
 
-        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new Publish($version);
+        $packet = new Publish(new Version4());
         $packet->setDup($dup);
 
         $reflection = new ReflectionClass('oliverlorenz\reactphpmqtt\packet\Publish');
@@ -177,8 +167,7 @@ class PublishTest extends PHPUnit_Framework_TestCase {
     {
         $retain = true;
 
-        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new Publish($version);
+        $packet = new Publish(new Version4());
         $packet->setRetain($retain);
 
         $reflection = new ReflectionClass('oliverlorenz\reactphpmqtt\packet\Publish');
@@ -195,8 +184,7 @@ class PublishTest extends PHPUnit_Framework_TestCase {
     {
         $topic = 'topictest';
 
-        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new Publish($version);
+        $packet = new Publish(new Version4());
         $return = $packet->setTopic($topic);
         $this->assertInstanceOf('oliverlorenz\reactphpmqtt\packet\Publish', $return);
     }
@@ -205,8 +193,7 @@ class PublishTest extends PHPUnit_Framework_TestCase {
     {
         $messageId = 1;
 
-        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new Publish($version);
+        $packet = new Publish(new Version4());
         $packet->setMessageId($messageId);
 
         $reflection = new ReflectionClass('oliverlorenz\reactphpmqtt\packet\Publish');
@@ -223,27 +210,26 @@ class PublishTest extends PHPUnit_Framework_TestCase {
     {
         $messageId = 1;
 
-        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $packet = new Publish($version);
+        $packet = new Publish(new Version4());
         $return = $packet->setMessageId($messageId);
         $this->assertInstanceOf('oliverlorenz\reactphpmqtt\packet\Publish', $return);
     }
 
     public function qosProvider() {
         return array(
-            array(0, 48),
-            array(1, 50),
-            array(2, 52),
+            array(0, 0b00110000),
+            array(1, 0b00110010),
+            array(2, 0b00110100),
         );
     }
 
     /**
      * @dataProvider qosProvider
      */
-    public function testParseWithQos($qos, $bit)
+    public function testParseWithQos($qos, $byte1)
     {
         $input =
-            chr($bit) .
+            chr($byte1) .
 //            chr(4) .
             chr(2) .
             chr(0) .
@@ -251,10 +237,9 @@ class PublishTest extends PHPUnit_Framework_TestCase {
             chr(0) .
             chr(10)*/
         ;
-        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $parsedPacket = Publish::parse($version, $input);
+        $parsedPacket = Publish::parse(new Version4(), $input);
 
-        $comparisonPacket = new Publish($version);
+        $comparisonPacket = new Publish(new Version4());
         $comparisonPacket->setQos($qos);
 
         $this->assertPacketEquals($comparisonPacket, $parsedPacket);
@@ -263,7 +248,7 @@ class PublishTest extends PHPUnit_Framework_TestCase {
     public function testParseWithRetain()
     {
         $input =
-            chr(49) .
+            chr(0b00110001) .
 //            chr(4) .
             chr(2) .
             chr(0) .
@@ -271,10 +256,9 @@ class PublishTest extends PHPUnit_Framework_TestCase {
             chr(0) .
             chr(10)*/
         ;
-        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $parsedPacket = Publish::parse($version, $input);
+        $parsedPacket = Publish::parse(new Version4(), $input);
 
-        $comparisonPacket = new Publish($version);
+        $comparisonPacket = new Publish(new Version4());
         $comparisonPacket->setRetain(true);
 
         $this->assertPacketEquals($comparisonPacket, $parsedPacket);
@@ -283,7 +267,7 @@ class PublishTest extends PHPUnit_Framework_TestCase {
     public function testParseWithDup()
     {
         $input =
-            chr(56) .
+            chr(0b00111000) .
 //            chr(4) .
             chr(2) .
             chr(0) .
@@ -291,20 +275,42 @@ class PublishTest extends PHPUnit_Framework_TestCase {
             chr(0) .
             chr(10)*/
         ;
-        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
-        $parsedPacket = Publish::parse($version, $input);
+        $parsedPacket = Publish::parse(new Version4(), $input);
 
-        $comparisonPacket = new Publish($version);
+        $comparisonPacket = new Publish(new Version4());
         $comparisonPacket->setDup(true);
 
         $this->assertPacketEquals($comparisonPacket, $parsedPacket);
     }
-    
+
+    public function testParseWithPayload()
+    {
+        $expectedPacket = new Publish(new Version4());
+        $expectedPacket->addRawToPayLoad('My payload');
+
+        $input =
+            chr(0b00110000) .
+            chr(12) .
+            chr(0) .
+            chr(0) .
+            'My payload';
+
+        $parsedPacket = Publish::parse(new Version4(), $input);
+
+        $this->assertPacketEquals($expectedPacket, $parsedPacket);
+    }
+
     private function assertPacketEquals(Publish $expected, Publish $actual)
     {
+        $this->assertEquals($expected, $actual);
+        $this->assertSerialisedPacketEquals($expected->get(), $actual->get());
+    }
+
+    private function assertSerialisedPacketEquals($expected, $actual)
+    {
         $this->assertEquals(
-            MessageHelper::getReadableByRawString($expected->get()),
-            MessageHelper::getReadableByRawString($actual->get())
+            MessageHelper::getReadableByRawString($expected),
+            MessageHelper::getReadableByRawString($actual)
         );
     }
 }

--- a/tests/unit/packet/PublishTest.php
+++ b/tests/unit/packet/PublishTest.php
@@ -16,6 +16,22 @@ class PublishTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(3, Publish::getControlPacketType());
     }
 
+    public function testExceptionIsThrownForUnexpectedPacketType()
+    {
+        $input =
+            chr(0b00100000) .
+            chr(2) .
+            chr(0) .
+            chr(0);
+
+        $this->setExpectedException(
+            'RuntimeException',
+            'raw input is not valid for this control packet'
+        );
+
+        Publish::parse(new Version4(), $input);
+    }
+
     public function testPublishStandardWithQos2()
     {
         $packet = new Publish(new Version4());


### PR DESCRIPTION
Hi. I think the content of a `Publish` message should go into the `$payload` property.

I've made the change and added an example, it's broken all the tests though. If you think it's correct I'll just change the tests to expect the messages in this form.