### PR TITLE
remove php nightly version test in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - nightly
 
 script:
   - composer install


### PR DESCRIPTION
because it could be php is broken. Nothing todo with the project itself