### PR TITLE
Keep Alive support

### DIFF
--- a/examples/config.php.example
+++ b/examples/config.php.example
@@ -3,7 +3,9 @@
 $config = array(
     'server' => 'yourMqttBroker.tld',
     'port' => 1883,
-    'options' => null,
+    'options' => new \oliverlorenz\reactphpmqtt\packet\ConnectionOptions(array(
+        'keepAlive' => 120,
+    )),
 );
 
 return $config;

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -122,7 +122,7 @@ class Connector implements ConnectorInterface {
     private function keepAlive(Stream $stream, $keepAlive)
     {
         if($keepAlive > 0) {
-            $interval = (int) ($keepAlive / 2);
+            $interval = $keepAlive / 2;
 
             $this->getLoop()->addPeriodicTimer($interval, function(Timer $timer) use ($stream) {
                 $packet = new PingRequest($this->version);

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -76,8 +76,8 @@ class Connector implements ConnectorInterface {
             ->then(function (Stream $stream) {
                 return $this->listenForPackets($stream);
             })
-            ->then(function(Stream $stream) {
-                return $this->keepAlive($stream);
+            ->then(function(Stream $stream) use ($options) {
+                return $this->keepAlive($stream, $options->keepAlive);
             });
     }
 
@@ -119,12 +119,16 @@ class Connector implements ConnectorInterface {
         return $deferred->promise();
     }
 
-    private function keepAlive(Stream $stream)
+    private function keepAlive(Stream $stream, $keepAlive)
     {
-        $this->getLoop()->addPeriodicTimer(10, function(Timer $timer) use ($stream) {
-            $packet = new PingRequest($this->version);
-            $this->sendPacketToStream($stream, $packet);
-        });
+        if($keepAlive > 0) {
+            $interval = (int) ($keepAlive / 2);
+
+            $this->getLoop()->addPeriodicTimer($interval, function(Timer $timer) use ($stream) {
+                $packet = new PingRequest($this->version);
+                $this->sendPacketToStream($stream, $packet);
+            });
+        }
 
         return new FulfilledPromise($stream);
     }
@@ -142,7 +146,8 @@ class Connector implements ConnectorInterface {
             $options->willTopic,
             $options->willMessage,
             $options->willQos,
-            $options->willRetain
+            $options->willRetain,
+            $options->keepAlive
         );
         $message = $packet->get();
         echo MessageHelper::getReadableByRawString($message);

--- a/src/packet/Connect.php
+++ b/src/packet/Connect.php
@@ -64,8 +64,7 @@ class Connect extends ControlPacket {
         $willMessage = null,
         $willQos = null,
         $willRetain = null,
-//        $keepAlive = 0
-        $keepAlive = 10
+        $keepAlive = 0
     ) {
         parent::__construct($version);
         $this->clientId = $clientId;

--- a/src/packet/Connect.php
+++ b/src/packet/Connect.php
@@ -39,6 +39,9 @@ class Connect extends ControlPacket {
     /** @var null */
     protected $willRetain;
 
+    /** @var int */
+    private $keepAlive;
+
     /**
      * @param Version $version
      * @param string|null $username
@@ -49,6 +52,7 @@ class Connect extends ControlPacket {
      * @param string|null $willMessage
      * @param bool|null $willQos
      * @param null $willRetain
+     * @param int $keepAlive
      */
     public function __construct(
         Version $version,
@@ -59,7 +63,9 @@ class Connect extends ControlPacket {
         $willTopic = null,
         $willMessage = null,
         $willQos = null,
-        $willRetain = null
+        $willRetain = null,
+//        $keepAlive = 0
+        $keepAlive = 10
     ) {
         parent::__construct($version);
         $this->clientId = $clientId;
@@ -70,6 +76,7 @@ class Connect extends ControlPacket {
         $this->willMessage = $willMessage;
         $this->willQos = boolval($willQos);
         $this->willRetain = $willRetain;
+        $this->keepAlive = $keepAlive;
         $this->buildPayload();
     }
 
@@ -101,14 +108,24 @@ class Connect extends ControlPacket {
      */
     protected function getVariableHeader()
     {
-        return chr(ControlPacketType::MOST_SIGNIFICANT_BYTE)         // byte 1
-        . chr(strlen($this->version->getProtocolIdentifierString())) // byte 2
-        . $this->version->getProtocolIdentifierString()              // byte 3,4,5,6
-        . chr($this->version->getProtocolVersion())                  // byte 7
-        . chr($this->getConnectFlags())                              // byte 8
-        . chr(0)                                                     // byte 9
-        . chr(10)                                                    // byte 10
-        ;
+        return chr(ControlPacketType::MOST_SIGNIFICANT_BYTE)              // byte 1
+             . chr(strlen($this->version->getProtocolIdentifierString())) // byte 2
+             . $this->version->getProtocolIdentifierString()              // byte 3,4,5,6
+             . chr($this->version->getProtocolVersion())                  // byte 7
+             . chr($this->getConnectFlags())                              // byte 8
+             . $this->getKeepAlive();                                     // byte 9,10
+    }
+
+    /**
+     * @return string
+     */
+    private function getKeepAlive()
+    {
+        $msb = $this->keepAlive >> 8;
+        $lsb = $this->keepAlive % 256;
+
+        return chr($msb)
+             . chr($lsb);
     }
 
     /**

--- a/src/packet/ConnectionOptions.php
+++ b/src/packet/ConnectionOptions.php
@@ -101,6 +101,16 @@ class ConnectionOptions
     public $willRetain = false;
 
     /**
+     * The Keep Alive is a time interval measured in seconds.
+     *
+     * @see http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Keep_Alive
+     *
+     * @var int
+     */
+//    public $keepAlive = 0;
+    public $keepAlive = 10;
+
+    /**
      * ConnectionOptions constructor.
      *
      * @param array $options [optional]

--- a/src/packet/ConnectionOptions.php
+++ b/src/packet/ConnectionOptions.php
@@ -107,8 +107,7 @@ class ConnectionOptions
      *
      * @var int
      */
-//    public $keepAlive = 0;
-    public $keepAlive = 10;
+    public $keepAlive = 0;
 
     /**
      * ConnectionOptions constructor.

--- a/tests/unit/packet/ConnectTest.php
+++ b/tests/unit/packet/ConnectTest.php
@@ -41,7 +41,7 @@ class ConnectTest extends PHPUnit_Framework_TestCase {
                 chr(4) .    // byte 7
                 chr(0) .    // byte 8
                 chr(0) .    // byte 9
-                chr(10)     // byte 10
+                chr(0)      // byte 10
             ),
             MessageHelper::getReadableByRawString(substr($packet->get(), 2, 10))
         );
@@ -59,7 +59,7 @@ class ConnectTest extends PHPUnit_Framework_TestCase {
                 chr(4) .    // byte 7
                 chr(2) .    // byte 8
                 chr(0) .    // byte 9
-                chr(10)     // byte 10
+                chr(0)      // byte 10
             ),
             MessageHelper::getReadableByRawString(substr($packet->get(), 2, 10))
         );
@@ -79,7 +79,7 @@ class ConnectTest extends PHPUnit_Framework_TestCase {
                 chr(4) .    // byte 7
                 chr(4) .    // byte 8
                 chr(0) .    // byte 9
-                chr(10)     // byte 10
+                chr(0)      // byte 10
             ),
             MessageHelper::getReadableByRawString(substr($packet->get(), 2, 10))
         );
@@ -99,7 +99,7 @@ class ConnectTest extends PHPUnit_Framework_TestCase {
                 chr(4) .    // byte 7
                 chr(32) .    // byte 8
                 chr(0) .    // byte 9
-                chr(10)     // byte 10
+                chr(0)      // byte 10
             ),
             MessageHelper::getReadableByRawString(substr($packet->get(), 2, 10))
         );
@@ -119,7 +119,7 @@ class ConnectTest extends PHPUnit_Framework_TestCase {
                 chr(4) .    // byte 7
                 chr(128) .    // byte 8
                 chr(0) .    // byte 9
-                chr(10)     // byte 10
+                chr(0)      // byte 10
             ),
             MessageHelper::getReadableByRawString(substr($packet->get(), 2, 10))
         );
@@ -139,7 +139,7 @@ class ConnectTest extends PHPUnit_Framework_TestCase {
                 chr(4) .    // byte 7
                 chr(64) .    // byte 8
                 chr(0) .    // byte 9
-                chr(10)     // byte 10
+                chr(0)      // byte 10
             ),
             MessageHelper::getReadableByRawString(substr($packet->get(), 2, 10))
         );
@@ -159,7 +159,7 @@ class ConnectTest extends PHPUnit_Framework_TestCase {
                 chr(4) .    // byte 7
                 chr(8) .    // byte 8
                 chr(0) .    // byte 9
-                chr(10)     // byte 10
+                chr(0)      // byte 10
             ),
             MessageHelper::getReadableByRawString(substr($packet->get(), 2, 10))
         );
@@ -179,7 +179,28 @@ class ConnectTest extends PHPUnit_Framework_TestCase {
                 chr(4) .    // byte 7
                 chr(194) .    // byte 8
                 chr(0) .    // byte 9
-                chr(10)     // byte 10
+                chr(0)      // byte 10
+            ),
+            MessageHelper::getReadableByRawString(substr($packet->get(), 2, 10))
+        );
+    }
+
+    public function testBytesNineAndTenOfVariableHeaderAreKeepAlive()
+    {
+        $version = new \oliverlorenz\reactphpmqtt\protocol\Version4();
+        $packet = new \oliverlorenz\reactphpmqtt\packet\Connect(
+            $version, null, null, null, true, null, null, null, null, 999
+        );
+
+        $this->assertEquals(
+            MessageHelper::getReadableByRawString(
+                chr(0) .    // byte 1
+                chr(4) .    // byte 2
+                'MQTT' .    // byte 3,4,5,6
+                chr(4) .    // byte 7
+                chr(2) .    // byte 8
+                chr(3) .    // byte 9
+                chr(231)    // byte 10
             ),
             MessageHelper::getReadableByRawString(substr($packet->get(), 2, 10))
         );


### PR DESCRIPTION
This adds support for being able to set the Keep Alive value, or not set the value, if you like.

It also fixes an issue where the client would get disconnected because it waited right until the Keep Alive time was up before Pinging. After running for a while, I would find that the client would always get disconnected, presumably because at some point it didn't manage to Ping in time.

The spec suggests the Keep Time time might be a couple of minutes, so I changed the example to use 2 minutes.