### PR TITLE
Cancel keep alive on close

### DIFF
--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -107,9 +107,13 @@ class MqttClient
         if($keepAlive > 0) {
             $interval = $keepAlive / 2;
 
-            $this->getLoop()->addPeriodicTimer($interval, function(Timer $timer) use ($stream) {
+            $timer = $this->getLoop()->addPeriodicTimer($interval, function(Timer $timer) use ($stream) {
                 $packet = new PingRequest($this->version);
                 $this->sendPacketToStream($stream, $packet);
+            });
+
+            $stream->on('close', function() use ($timer) {
+                $this->getLoop()->cancelTimer($timer);
             });
         }
 

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -23,7 +23,6 @@ use oliverlorenz\reactphpmqtt\packet\UnsubscribeAck;
 use oliverlorenz\reactphpmqtt\protocol\Version;
 use oliverlorenz\reactphpmqtt\protocol\Violation as ProtocolViolation;
 use React\EventLoop\LoopInterface as Loop;
-use React\EventLoop\Timer\Timer;
 use React\Promise\Deferred;
 use React\Promise\FulfilledPromise;
 use React\Promise\PromiseInterface;
@@ -107,7 +106,7 @@ class MqttClient
         if($keepAlive > 0) {
             $interval = $keepAlive / 2;
 
-            $timer = $this->getLoop()->addPeriodicTimer($interval, function(Timer $timer) use ($stream) {
+            $timer = $this->getLoop()->addPeriodicTimer($interval, function() use ($stream) {
                 $packet = new PingRequest($this->version);
                 $this->sendPacketToStream($stream, $packet);
             });


### PR DESCRIPTION
This stops the client from trying to send pings to the server, if it has been disconnected.

I've been looking at how to reconnect to the server if it goes away and then comes back again (eg if I restart my Home Assistant server), and I found that I can get it to reconnect, but it starts sending two lots of pings, one that works and one that doesn't get a response. This should resolve that.