### PR TITLE
Add debug output using a PSR3 logger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         }
     },
     "require": {
-        "react/socket": "^1.1"
+        "react/socket": "^1.1",
+        "psr/log": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0.0"

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -3,6 +3,7 @@
 namespace oliverlorenz\reactphpmqtt;
 
 use oliverlorenz\reactphpmqtt\protocol\Version;
+use Psr\Log\LoggerInterface;
 use React\Dns\Resolver\Factory as DnsResolverFactory;
 use React\EventLoop\Factory as EventLoopFactory;
 use React\Socket\DnsConnector;
@@ -11,21 +12,21 @@ use React\Socket\TcpConnector;
 
 class ClientFactory
 {
-    public static function createClient(Version $version, $resolverIp = '8.8.8.8')
+    public static function createClient(Version $version, $resolverIp = '8.8.8.8', LoggerInterface $logger = null)
     {
         $loop = EventLoopFactory::create();
         $connector = self::createDnsConnector($resolverIp, $loop);
 
-        return new MqttClient($loop, $connector, $version);
+        return new MqttClient($loop, $connector, $version, $logger);
     }
 
-    public static function createSecureClient(Version $version, $resolverIp = '8.8.8.8')
+    public static function createSecureClient(Version $version, $resolverIp = '8.8.8.8', LoggerInterface $logger = null)
     {
         $loop = EventLoopFactory::create();
         $connector = self::createDnsConnector($resolverIp, $loop);
         $secureConnector = new SecureConnector($connector, $loop);
 
-        return new MqttClient($loop, $secureConnector, $version);
+        return new MqttClient($loop, $secureConnector, $version, $logger);
     }
 
     private static function createDnsConnector($resolverIp, $loop)

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -12,21 +12,21 @@ use React\Socket\TcpConnector;
 
 class ClientFactory
 {
-    public static function createClient(Version $version, $resolverIp = '8.8.8.8')
+    public static function createClient(Version $version, $resolverIp = '8.8.8.8', LoggerInterface $logger = null)
     {
         $loop = EventLoopFactory::create();
         $connector = self::createDnsConnector($resolverIp, $loop);
 
-        return new MqttClient($loop, $connector, $version);
+        return new MqttClient($loop, $connector, $version, $logger);
     }
 
-    public static function createSecureClient(Version $version, $resolverIp = '8.8.8.8')
+    public static function createSecureClient(Version $version, $resolverIp = '8.8.8.8', LoggerInterface $logger = null)
     {
         $loop = EventLoopFactory::create();
         $connector = self::createDnsConnector($resolverIp, $loop);
         $secureConnector = new SecureConnector($connector, $loop);
 
-        return new MqttClient($loop, $secureConnector, $version);
+        return new MqttClient($loop, $secureConnector, $version, $logger);
     }
 
     private static function createDnsConnector($resolverIp, $loop)

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -12,21 +12,21 @@ use React\Socket\TcpConnector;
 
 class ClientFactory
 {
-    public static function createClient(Version $version, $resolverIp = '8.8.8.8', LoggerInterface $logger = null)
+    public static function createClient(Version $version, $resolverIp = '8.8.8.8')
     {
         $loop = EventLoopFactory::create();
         $connector = self::createDnsConnector($resolverIp, $loop);
 
-        return new MqttClient($loop, $connector, $version, $logger);
+        return new MqttClient($loop, $connector, $version);
     }
 
-    public static function createSecureClient(Version $version, $resolverIp = '8.8.8.8', LoggerInterface $logger = null)
+    public static function createSecureClient(Version $version, $resolverIp = '8.8.8.8')
     {
         $loop = EventLoopFactory::create();
         $connector = self::createDnsConnector($resolverIp, $loop);
         $secureConnector = new SecureConnector($connector, $loop);
 
-        return new MqttClient($loop, $secureConnector, $version, $logger);
+        return new MqttClient($loop, $secureConnector, $version);
     }
 
     private static function createDnsConnector($resolverIp, $loop)

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -43,11 +43,18 @@ class MqttClient
 
     private $messageCounter = 1;
 
-    public function __construct(Loop $loop, ReactConnector $connector, Version $version, LoggerInterface $logger = null)
+    public function __construct(Loop $loop, ReactConnector $connector, Version $version)
     {
         $this->version = $version;
         $this->socketConnector = $connector;
         $this->loop = $loop;
+    }
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
         $this->logger = $logger;
     }
 

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -22,6 +22,7 @@ use oliverlorenz\reactphpmqtt\packet\Unsubscribe;
 use oliverlorenz\reactphpmqtt\packet\UnsubscribeAck;
 use oliverlorenz\reactphpmqtt\protocol\Version;
 use oliverlorenz\reactphpmqtt\protocol\Violation as ProtocolViolation;
+use Psr\Log\LoggerInterface;
 use React\EventLoop\LoopInterface as Loop;
 use React\EventLoop\Timer\Timer;
 use React\Promise\Deferred;
@@ -38,14 +39,16 @@ class MqttClient
     private $loop;
     private $socketConnector;
     private $version;
+    private $logger;
 
     private $messageCounter = 1;
 
-    public function __construct(Loop $loop, ReactConnector $connector, Version $version)
+    public function __construct(Loop $loop, ReactConnector $connector, Version $version, LoggerInterface $logger = null)
     {
         $this->version = $version;
         $this->socketConnector = $connector;
         $this->loop = $loop;
+        $this->logger = $logger;
     }
 
     /**
@@ -85,7 +88,7 @@ class MqttClient
             try {
                 foreach (Factory::getNextPacket($this->version, $rawData) as $packet) {
                     $stream->emit($packet::EVENT, [$packet]);
-                    #echo "received:\t" . get_class($packet) . PHP_EOL; // TODO: wrap in a logger
+                    $this->debug("received:\t" . get_class($packet));
                 }
             }
             catch (ProtocolViolation $e) {
@@ -133,7 +136,7 @@ class MqttClient
             $options->keepAlive
         );
         $message = $packet->get();
-        #echo MessageHelper::getReadableByRawString($message); // TODO: wrap into a logger
+        $this->debug(MessageHelper::getReadableByRawString($message));
 
         $deferred = new Deferred();
         $stream->on(ConnectionAck::EVENT, function($message) use ($stream, $deferred) {
@@ -153,7 +156,8 @@ class MqttClient
 
     private function sendPacketToStream(Connection $stream, ControlPacket $controlPacket)
     {
-        #echo "send:\t\t" . get_class($controlPacket) . "\n"; // TODO: wrap it to a logger...
+        $this->debug("send:\t\t" . get_class($controlPacket));
+
         $message = $controlPacket->get();
 
         return $stream->write($message);
@@ -248,5 +252,11 @@ class MqttClient
     private function getDefaultConnectionOptions()
     {
         return new ConnectionOptions();
+    }
+
+    private function debug($message) {
+        if ($this->logger !== null) {
+            $this->logger->debug($message);
+        }
     }
 }

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -85,7 +85,7 @@ class MqttClient
             try {
                 foreach (Factory::getNextPacket($this->version, $rawData) as $packet) {
                     $stream->emit($packet::EVENT, [$packet]);
-                    echo "received:\t" . get_class($packet) . PHP_EOL;
+                    #echo "received:\t" . get_class($packet) . PHP_EOL; // TODO: wrap in a logger
                 }
             }
             catch (ProtocolViolation $e) {
@@ -133,7 +133,7 @@ class MqttClient
             $options->keepAlive
         );
         $message = $packet->get();
-        echo MessageHelper::getReadableByRawString($message);
+        #echo MessageHelper::getReadableByRawString($message); // TODO: wrap into a logger
 
         $deferred = new Deferred();
         $stream->on(ConnectionAck::EVENT, function($message) use ($stream, $deferred) {
@@ -153,7 +153,7 @@ class MqttClient
 
     private function sendPacketToStream(Connection $stream, ControlPacket $controlPacket)
     {
-        echo "send:\t\t" . get_class($controlPacket) . "\n";
+        #echo "send:\t\t" . get_class($controlPacket) . "\n"; // TODO: wrap it to a logger...
         $message = $controlPacket->get();
 
         return $stream->write($message);

--- a/src/MqttClient.php
+++ b/src/MqttClient.php
@@ -43,17 +43,18 @@ class MqttClient
 
     private $messageCounter = 1;
 
-    public function __construct(Loop $loop, ReactConnector $connector, Version $version)
+    public function __construct(Loop $loop, ReactConnector $connector, Version $version, LoggerInterface $logger = null)
     {
         $this->version = $version;
         $this->socketConnector = $connector;
         $this->loop = $loop;
+        $this->logger = $logger;
     }
 
     /**
-     * @param LoggerInterface $logger
+     * @param LoggerInterface|null $logger
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger = null)
     {
         $this->logger = $logger;
     }


### PR DESCRIPTION
As discussed in #31, echoing is not that great for providing debug output.

This PR introduces a $logger parameter to the ClientFactory that is passed through to the MqttClient. The $logger provided should conform to the PSR3 LoggerInterface. I have done a bit of manual testing with https://github.com/WyriHaximus/reactphp-psr-3-stdio and that worked. Small example:

        $loop = $client->getLoop();
        $logger = StdioLogger::create($loop);
        $client->setLogger($logger);

The MqttClient currently uses a private function debug() to log the messages that were echoed at the debug level.